### PR TITLE
Add Signing Algorithm selection support to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Here is a breakdown of what each attribute means:
 
 `auth0.servletFilterEnabled` - This is a boolean value that switches having an authentication filter enabled On / Off.
 
+The default JWT Signing Algorithm is `HS256`. This is HMAC SHA256, a symmetric crypographic algorithm (HMAC), that uses the `clientSecret` to
+verify a signed JWT token. However, if you wish to configure this library to use an alternate cryptographic algorithm then use the two
+options below. The Auth0 Dashboard offers the choice between `HS256` and `RS256`. 'RS256' is RSA SHA256 and uses a public key cryptographic
+algorithm (RSA), that requires knowledge of the application public key to verify a signed JWT Token (that was signed with a private key).
+You can download the application's public key from the Auth0 Dashboard and store it inside your application's WEB-INF directory. 
+
+The following two attributes are required when configuring your application with this library to use `RSA` instead of `HMAC`:
+
+`auth0.signing_algorithm` - This is signing algorithm to verify signed JWT token. Use `HS256` or `RS256`. 
+
+`auth0.public_key_path` - This is the path location to the public key stored locally on disk / inside your application War file WEB-INF directory. Should always be set when using `RS256`. 
+
 
 ## Extension Points in Library
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
 
         <!-- Test -->

--- a/src/main/java/com/auth0/web/Auth0Config.java
+++ b/src/main/java/com/auth0/web/Auth0Config.java
@@ -61,6 +61,18 @@ public class Auth0Config {
     @Value(value = "${auth0.securedRoute}")
     protected String securedRoute;
 
+    /**
+     * default to HS256 for backwards compatibility
+     */
+    @Value(value = "${auth0.signingAlgorithm:HS256}")
+    protected String signingAlgorithm;
+
+    /**
+     * default to empty string as HS256 is default
+     */
+    @Value(value = "${auth0.publicKeyPath:}")
+    protected String publicKeyPath;
+
 
     public String getDomain() {
         return domain;
@@ -96,6 +108,14 @@ public class Auth0Config {
 
     public String getSecuredRoute() {
         return securedRoute;
+    }
+
+    public String getSigningAlgorithm() {
+        return signingAlgorithm;
+    }
+
+    public String getPublicKeyPath() {
+        return publicKeyPath;
     }
 
 }


### PR DESCRIPTION
Currently, only `HS256` support is available. This PR permits the configuration of `RS256` support when used with `Auth0`. The default algorithm remains as `HS256` if no configuration provided, hence backwards compatible and only requires a minor version update when publishing to Maven.