### PR TITLE
Make issuer is a required JWT verification setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Here is an example:
 
 ```
 auth0.domain: {your domain}
+auth0.issuer: {your issuer} 
 auth0.clientId: {your client id}
 auth0.clientSecret: {your secret}
 auth0.onLogoutRedirectTo: /login
@@ -89,6 +90,8 @@ Please take a look at the sample that accompanies this library for an easy seed 
 Here is a breakdown of what each attribute means:
 
 `auth0.domain` - This is your auth0 domain (tenant you have created when registering with auth0 - account name)
+
+`auth0.issuer` - This is the issuer of the JWT Token (typically full URL of your auth0 tenant account - eg. https://{tenant_name}.auth0.com/)
 
 `auth0.clientId` - This is the client id of your auth0 application (see Settings page on auth0 dashboard)
 

--- a/src/main/java/com/auth0/web/Auth0Config.java
+++ b/src/main/java/com/auth0/web/Auth0Config.java
@@ -37,6 +37,9 @@ public class Auth0Config {
     @Value(value = "${auth0.domain}")
     protected String domain;
 
+    @Value(value = "${auth0.issuer}")
+    protected String issuer;
+
     @Value(value = "${auth0.clientId}")
     protected String clientId;
 
@@ -76,6 +79,10 @@ public class Auth0Config {
 
     public String getDomain() {
         return domain;
+    }
+
+    public String getIssuer() {
+        return issuer;
     }
 
     public String getClientId() {

--- a/src/main/java/com/auth0/web/Auth0Filter.java
+++ b/src/main/java/com/auth0/web/Auth0Filter.java
@@ -55,6 +55,8 @@ public class Auth0Filter implements Filter {
     public void init(final FilterConfig filterConfig) throws ServletException {
         onFailRedirectTo = filterConfig.getInitParameter("redirectOnAuthError");
         Validate.notNull(onFailRedirectTo);
+        final String issuer = auth0Config.getIssuer();
+        Validate.notNull(issuer);
         final String clientId = auth0Config.getClientId();
         Validate.notNull(clientId);
         final String signingAlgorithmStr = auth0Config.getSigningAlgorithm();
@@ -65,7 +67,7 @@ public class Auth0Filter implements Filter {
             case HS512:
                 final String clientSecret = auth0Config.getClientSecret();
                 Validate.notNull(clientSecret);
-                jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId);
+                jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId, issuer);
                 return;
             case RS256:
             case RS384:
@@ -77,7 +79,7 @@ public class Auth0Filter implements Filter {
                     final String publicKeyRealPath = context.getRealPath(publicKeyPath);
                     final PublicKey publicKey = readPublicKey(publicKeyRealPath);
                     Validate.notNull(publicKey);
-                    jwtVerifier = new JWTVerifier(publicKey, clientId);
+                    jwtVerifier = new JWTVerifier(publicKey, clientId, issuer);
                     return;
                 } catch (Exception e) {
                     throw new IllegalStateException(e.getMessage(), e.getCause());


### PR DESCRIPTION
This updates the library to ensure that issuer is set as a configuration setting for JWT verification purposes in line with best practices.