### PR TITLE
Option to disable base64Encoded secret

### DIFF
--- a/src/main/java/com/auth0/web/Auth0Config.java
+++ b/src/main/java/com/auth0/web/Auth0Config.java
@@ -67,6 +67,12 @@ public class Auth0Config {
     protected String securedRoute;
 
     /**
+     * This is a boolean value indicating whether the Secret used to verify the JWT is base64 encoded. Default is `false`
+     */
+    @Value(value = "${auth0.base64EncodedSecret}")
+    protected boolean base64EncodedSecret;
+
+    /**
      * This is signing algorithm to verify signed JWT token. Use `HS256` or `RS256`.
      * Default to HS256 for backwards compatibility
      */
@@ -116,6 +122,10 @@ public class Auth0Config {
 
     public String getSecuredRoute() {
         return securedRoute;
+    }
+
+    public boolean isBase64EncodedSecret() {
+        return base64EncodedSecret;
     }
 
     public String getSigningAlgorithm() {

--- a/src/main/java/com/auth0/web/Auth0Config.java
+++ b/src/main/java/com/auth0/web/Auth0Config.java
@@ -67,9 +67,9 @@ public class Auth0Config {
     protected String securedRoute;
 
     /**
-     * This is a boolean value indicating whether the Secret used to verify the JWT is base64 encoded. Default is `false`
+     * This is a boolean value indicating whether the Secret used to verify the JWT is base64 encoded. Default is `true`
      */
-    @Value(value = "${auth0.base64EncodedSecret}")
+    @Value(value = "${auth0.base64EncodedSecret:true}")
     protected boolean base64EncodedSecret;
 
     /**

--- a/src/main/java/com/auth0/web/Auth0Filter.java
+++ b/src/main/java/com/auth0/web/Auth0Filter.java
@@ -59,10 +59,10 @@ public class Auth0Filter implements Filter {
                 final String clientSecret = auth0Config.getClientSecret();
                 Validate.notNull(clientSecret);
                 final boolean base64EncodedSecret = auth0Config.isBase64EncodedSecret();
-                Validate.notNull(base64EncodedSecret);
                 // Auth0 Client Secrets are not Base64 encoded by default
                 if (base64EncodedSecret) {
-                    jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId, issuer);
+                    final Base64 base64 = new Base64(true);
+                    jwtVerifier = new JWTVerifier(base64.decode(clientSecret), clientId, issuer);
                 } else {
                     jwtVerifier = new JWTVerifier(clientSecret, clientId, issuer);
                 }

--- a/src/main/java/com/auth0/web/Auth0Filter.java
+++ b/src/main/java/com/auth0/web/Auth0Filter.java
@@ -58,7 +58,14 @@ public class Auth0Filter implements Filter {
             case HS512:
                 final String clientSecret = auth0Config.getClientSecret();
                 Validate.notNull(clientSecret);
-                jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId, issuer);
+                final boolean base64EncodedSecret = auth0Config.isBase64EncodedSecret();
+                Validate.notNull(base64EncodedSecret);
+                // Auth0 Client Secrets are not Base64 encoded by default
+                if (base64EncodedSecret) {
+                    jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId, issuer);
+                } else {
+                    jwtVerifier = new JWTVerifier(clientSecret, clientId, issuer);
+                }
                 return;
             case RS256:
             case RS384:


### PR DESCRIPTION
Only merge this PR when Auth0 officially switches to client secrets that are not base64 encoded.
